### PR TITLE
Fix performance of Assets

### DIFF
--- a/src/api/accountBalances.ts
+++ b/src/api/accountBalances.ts
@@ -14,7 +14,7 @@ export const useAccountBalances = (id: Maybe<AccountId32 | string>) => {
   )
 }
 
-const getAccountBalances =
+export const getAccountBalances =
   (api: ApiPromise, accountId: AccountId32 | string) => async () => {
     const [tokens, native] = await Promise.all([
       api.query.tokens.accounts.entries(accountId),

--- a/src/api/assetDetails.ts
+++ b/src/api/assetDetails.ts
@@ -1,12 +1,20 @@
-import { NATIVE_ASSET_ID, useApiPromise } from "utils/api"
+import { NATIVE_ASSET_ID, useApiPromise, useTradeRouter } from "utils/api"
 import { useQuery } from "@tanstack/react-query"
 import { QUERY_KEYS } from "utils/queryKeys"
 import { ApiPromise } from "@polkadot/api"
-import { u32 } from "@polkadot/types"
+import { u32, u8 } from "@polkadot/types"
 import { Maybe, normalizeId, isNotNil } from "utils/helpers"
-import { useAccountBalances } from "./accountBalances"
+import { getAccountBalances, useAccountBalances } from "./accountBalances"
 import { AccountId32 } from "@polkadot/types/interfaces"
 import { PalletAssetRegistryAssetType } from "@polkadot/types/lookup"
+import { getAssetsBalances } from "sections/wallet/assets/table/data/WalletAssetsTableData.utils"
+import { useAccountStore } from "state/store"
+import { getAcceptedCurrency, getAccountCurrency } from "./payments"
+import { getAssetName } from "components/AssetIcon/AssetIcon"
+import { getApiIds } from "./consts"
+import { getSpotPrice } from "./spotPrice"
+import { getTokenLock } from "./balances"
+import { getHubAssetTradability, getOmnipoolAssets } from "./omnipool"
 
 export const useAssetDetails = (id: Maybe<u32 | string>) => {
   const api = useApiPromise()
@@ -17,6 +25,73 @@ export const useAssetDetails = (id: Maybe<u32 | string>) => {
 
 interface AssetDetailsListFilter {
   assetType: PalletAssetRegistryAssetType["type"][]
+}
+
+export const useAssetTable = () => {
+  const api = useApiPromise()
+  const tradeRouter = useTradeRouter()
+
+  const { account } = useAccountStore()
+
+  return useQuery(
+    QUERY_KEYS.assetsTable(account?.address),
+    async () => {
+      if (!account?.address) return undefined
+
+      const balances = await getAccountBalances(api, account.address)()
+
+      const allAcceptedTokens = [
+        NATIVE_ASSET_ID,
+        ...(balances.balances ?? []).map((balance) => balance.id),
+      ].map((id) => getAcceptedCurrency(api, id)())
+
+      const acceptedTokens = await Promise.all(allAcceptedTokens)
+
+      const accountTokenId = await getAccountCurrency(api, account.address)()
+
+      const apiIds = await getApiIds(api)()
+
+      const allAssets = await getAssetsTableDetails(api)()
+
+      const tradeAssets = await tradeRouter.getAllAssets()
+
+      const spotPricePromises = acceptedTokens.map((token) =>
+        getSpotPrice(tradeRouter, token.id, apiIds.usdId ?? "")(),
+      )
+      const spotPrices = await Promise.all(spotPricePromises)
+      const tokenLockPromises = acceptedTokens.map((token) =>
+        getTokenLock(api, account.address, token.id)(),
+      )
+
+      const tokenLocks = await Promise.all(tokenLockPromises)
+
+      const omnipoolAssets = await getOmnipoolAssets(api)()
+
+      const hubAssetTradability = await getHubAssetTradability(api)()
+
+      const assetsBalances = getAssetsBalances(
+        balances.balances,
+        spotPrices,
+        allAssets,
+        tokenLocks,
+        balances.native,
+      )
+
+      return {
+        allAssets,
+        accountTokenId,
+        tradeAssets,
+        acceptedTokens,
+        assetsBalances,
+        apiIds,
+        omnipoolAssets,
+        hubAssetTradability,
+      }
+    },
+    {
+      enabled: !!account?.address,
+    },
+  )
 }
 
 export const useAssetDetailsList = (
@@ -76,6 +151,71 @@ const getAssetDetails = (api: ApiPromise) => async () => {
       locked: false,
       name: system.tokenSymbol.unwrap()[0].toString(),
       assetType: "Token",
+    })
+  }
+
+  return assets
+}
+
+export const getAssetsTableDetails = (api: ApiPromise) => async () => {
+  const [system, rawAssetsData, rawAssetsMeta] = await Promise.all([
+    api.rpc.system.properties(),
+    api.query.assetRegistry.assets.entries(),
+    api.query.assetRegistry.assetMetadataMap.entries(),
+  ])
+
+  const assetsMeta: Array<{
+    id: string
+    symbol: string
+    decimals: u8 | u32
+  }> = rawAssetsMeta.map(([key, data]) => {
+    return {
+      id: key.args[0].toString(),
+      symbol: data.unwrap().symbol.toUtf8(),
+      decimals: data.unwrap().decimals,
+    }
+  })
+
+  if (!assetsMeta.find((i) => i.id === NATIVE_ASSET_ID)) {
+    const [decimals] = system.tokenDecimals.unwrap()
+    const [symbol] = system.tokenSymbol.unwrap()
+
+    assetsMeta.push({
+      id: NATIVE_ASSET_ID,
+      symbol: symbol.toString(),
+      decimals,
+    })
+  }
+
+  const assets = rawAssetsData.map(([key, data]) => {
+    const { symbol = "N/A", decimals } =
+      assetsMeta.find(
+        (assetMeta) => assetMeta.id.toString() === key.args[0].toString(),
+      ) || {}
+
+    return {
+      id: key.args[0].toString(),
+      name: data.unwrap().name.toUtf8() || getAssetName(symbol),
+      locked: data.unwrap().locked.toPrimitive(),
+      assetType: data.unwrap().assetType.type,
+      symbol,
+      decimals,
+    }
+  })
+
+  if (!assets.find((i) => i.id === NATIVE_ASSET_ID)) {
+    const { symbol = "N/A", decimals } =
+      assetsMeta.find(
+        (assetMeta) => assetMeta.id.toString() === NATIVE_ASSET_ID,
+      ) || {}
+
+    assets.push({
+      id: NATIVE_ASSET_ID,
+      locked: false,
+      name: system.tokenSymbol.unwrap()[0].toString() || getAssetName(symbol),
+      assetType: "Token",
+      symbol,
+      decimals,
     })
   }
 

--- a/src/api/payments.ts
+++ b/src/api/payments.ts
@@ -9,17 +9,18 @@ import { u32 } from "@polkadot/types-codec"
 import { AccountId32 } from "@open-web3/orml-types/interfaces"
 import { usePaymentInfo } from "./transaction"
 
-const getAcceptedCurrency = (api: ApiPromise, id: u32 | string) => async () => {
-  const normalizedId = normalizeId(id)
-  const result = await api.query.multiTransactionPayment.acceptedCurrencies(
-    normalizedId,
-  )
+export const getAcceptedCurrency =
+  (api: ApiPromise, id: u32 | string) => async () => {
+    const normalizedId = normalizeId(id)
+    const result = await api.query.multiTransactionPayment.acceptedCurrencies(
+      normalizedId,
+    )
 
-  return {
-    id: normalizedId,
-    accepted: !result.isEmpty,
+    return {
+      id: normalizedId,
+      accepted: !result.isEmpty,
+    }
   }
-}
 
 export const useAcceptedCurrencies = (ids: Maybe<string | u32>[]) => {
   const api = useApiPromise()
@@ -61,7 +62,7 @@ export const useSetAsFeePayment = () => {
   }
 }
 
-const getAccountCurrency =
+export const getAccountCurrency =
   (api: ApiPromise, address: string | AccountId32) => async () => {
     const result = await api.query.multiTransactionPayment.accountCurrencyMap(
       address,

--- a/src/sections/wallet/assets/WalletAssets.tsx
+++ b/src/sections/wallet/assets/WalletAssets.tsx
@@ -1,63 +1,23 @@
-import { useAssetsTableData } from "sections/wallet/assets/table/data/WalletAssetsTableData.utils"
 import { WalletAssetsTablePlaceholder } from "sections/wallet/assets/table/placeholder/WalletAssetsTablePlaceholder"
-import { WalletAssetsTableSkeleton } from "sections/wallet/assets/table/skeleton/WalletAssetsTableSkeleton"
-import { WalletAssetsTable } from "sections/wallet/assets/table/WalletAssetsTable"
 import { useAccountStore } from "state/store"
 import { WalletAssetsHeader } from "./WalletAssetsHeader"
-import { WalletAssetsHydraPositions } from "sections/wallet/assets/hydraPositions/WalletAssetsHydraPositions"
-import { useHydraPositionsData } from "sections/wallet/assets/hydraPositions/data/WalletAssetsHydraPositionsData.utils"
-import { WalletAssetsHydraPositionsSkeleton } from "sections/wallet/assets/hydraPositions/skeleton/WalletAssetsHydraPositionsSkeleton"
-import { Spacer } from "components/Spacer/Spacer"
+import { WalletAssetsTableWrapper } from "./table/WalletAssetsTableWrapper"
+import { WalletAssetsPositionsWrapper } from "./hydraPositions/WalletAssetsPositionsWrapper"
 
 export const WalletAssets = () => {
   const { account } = useAccountStore()
-  const assetsTable = useAssetsTableData()
-  const positionsTable = useHydraPositionsData()
 
   return (
     <div sx={{ mt: [34, 56] }}>
       {!account ? (
         <>
-          <WalletAssetsHeader
-            isLoading={true}
-            data={assetsTable.data}
-            disabledAnimation
-          />
+          <WalletAssetsHeader isLoading={true} disabledAnimation />
           <WalletAssetsTablePlaceholder />
         </>
       ) : (
         <>
-          <WalletAssetsHeader
-            isLoading={assetsTable.isLoading}
-            data={assetsTable.data}
-          />
-          <div
-            sx={{
-              display: "flex",
-              flexDirection: "column",
-              gap: [0, 20],
-            }}
-          >
-            {assetsTable.isLoading ? (
-              <WalletAssetsTableSkeleton />
-            ) : (
-              <WalletAssetsTable data={assetsTable.data} />
-            )}
-            <Spacer
-              size={10}
-              sx={{
-                bg: "darkBlue700",
-                mx: "-12px",
-                width: "calc(100% + 24px)",
-                display: ["inherit", "none"],
-              }}
-            />
-            {positionsTable.isLoading ? (
-              <WalletAssetsHydraPositionsSkeleton />
-            ) : (
-              <WalletAssetsHydraPositions data={positionsTable.data} />
-            )}
-          </div>
+          <WalletAssetsTableWrapper />
+          <WalletAssetsPositionsWrapper />
         </>
       )}
     </div>

--- a/src/sections/wallet/assets/hydraPositions/WalletAssetsPositionsWrapper.tsx
+++ b/src/sections/wallet/assets/hydraPositions/WalletAssetsPositionsWrapper.tsx
@@ -1,0 +1,11 @@
+import { WalletAssetsHydraPositions } from "./WalletAssetsHydraPositions"
+import { useHydraPositionsData } from "./data/WalletAssetsHydraPositionsData.utils"
+import { WalletAssetsHydraPositionsSkeleton } from "./skeleton/WalletAssetsHydraPositionsSkeleton"
+
+export const WalletAssetsPositionsWrapper = () => {
+  const positionsTable = useHydraPositionsData()
+
+  if (positionsTable.isLoading) return <WalletAssetsHydraPositionsSkeleton />
+
+  return <WalletAssetsHydraPositions data={positionsTable.data} />
+}

--- a/src/sections/wallet/assets/table/WalletAssetsTable.tsx
+++ b/src/sections/wallet/assets/table/WalletAssetsTable.tsx
@@ -24,12 +24,15 @@ import { WalletTransferModal } from "sections/wallet/transfer/WalletTransferModa
 import { theme } from "theme"
 import { WalletAssetsTableActionsMob } from "./actions/WalletAssetsTableActionsMob"
 
-type Props = { data: AssetsTableData[] }
+type Props = {
+  data: AssetsTableData[]
+  showAll: boolean
+  setShowAll: (value: boolean) => void
+}
 
-export const WalletAssetsTable = ({ data }: Props) => {
+export const WalletAssetsTable = ({ data, setShowAll, showAll }: Props) => {
   const { t } = useTranslation()
   const [row, setRow] = useState<AssetsTableData | undefined>(undefined)
-  const [showAll, setShowAll] = useState(false)
   const [transferAsset, setTransferAsset] = useState<string | null>(null)
 
   const isDesktop = useMedia(theme.viewport.gte.sm)

--- a/src/sections/wallet/assets/table/WalletAssetsTable.utils.tsx
+++ b/src/sections/wallet/assets/table/WalletAssetsTable.utils.tsx
@@ -7,9 +7,8 @@ import {
   useReactTable,
   VisibilityState,
 } from "@tanstack/react-table"
-import { Trans, useTranslation } from "react-i18next"
+import { useTranslation } from "react-i18next"
 import { useState } from "react"
-import { useSetAsFeePayment } from "api/payments"
 import {
   WalletAssetsTableBalance,
   WalletAssetsTableName,
@@ -28,7 +27,6 @@ export const useAssetsTable = (
   const { t } = useTranslation()
   const { accessor, display } = createColumnHelper<AssetsTableData>()
   const [sorting, setSorting] = useState<SortingState>([])
-  const setFeeAsPayment = useSetAsFeePayment()
 
   const isDesktop = useMedia(theme.viewport.gte.sm)
   const columnVisibility: VisibilityState = {
@@ -74,46 +72,6 @@ export const useAssetsTable = (
       id: "actions",
       cell: ({ row }) => (
         <WalletAssetsTableActions
-          onSetFeeAsPaymentClick={() =>
-            setFeeAsPayment(row.original.id, {
-              onLoading: (
-                <Trans
-                  t={t}
-                  i18nKey="wallet.assets.table.actions.payment.toast.onLoading"
-                  tOptions={{
-                    asset: row.original.symbol,
-                  }}
-                >
-                  <span />
-                  <span className="highlight" />
-                </Trans>
-              ),
-              onSuccess: (
-                <Trans
-                  t={t}
-                  i18nKey="wallet.assets.table.actions.payment.toast.onSuccess"
-                  tOptions={{
-                    asset: row.original.symbol,
-                  }}
-                >
-                  <span />
-                  <span className="highlight" />
-                </Trans>
-              ),
-              onError: (
-                <Trans
-                  t={t}
-                  i18nKey="wallet.assets.table.actions.payment.toast.onLoading"
-                  tOptions={{
-                    asset: row.original.symbol,
-                  }}
-                >
-                  <span />
-                  <span className="highlight" />
-                </Trans>
-              ),
-            })
-          }
           couldBeSetAsPaymentFee={row.original.couldBeSetAsPaymentFee}
           onBuyClick={
             row.original.tradability.inTradeRouter &&
@@ -139,6 +97,7 @@ export const useAssetsTable = (
           isExpanded={row.getIsSelected()}
           onTransferClick={() => actions.onTransfer(row.original.id)}
           symbol={row.original.symbol}
+          id={row.original.id}
         />
       ),
     }),

--- a/src/sections/wallet/assets/table/WalletAssetsTableWrapper.tsx
+++ b/src/sections/wallet/assets/table/WalletAssetsTableWrapper.tsx
@@ -1,0 +1,31 @@
+import { useState } from "react"
+import { Spacer } from "components/Spacer/Spacer"
+import { WalletAssetsHeader } from "../WalletAssetsHeader"
+import { WalletAssetsTable } from "./WalletAssetsTable"
+import { useAssetsTableData } from "./data/WalletAssetsTableData.utils"
+import { WalletAssetsTableSkeleton } from "./skeleton/WalletAssetsTableSkeleton"
+
+export const WalletAssetsTableWrapper = () => {
+  const [showAll, setShowAll] = useState(false)
+
+  const assetsTable = useAssetsTableData(showAll)
+
+  return (
+    <>
+      <WalletAssetsHeader
+        isLoading={assetsTable.isLoading}
+        data={assetsTable.data}
+      />
+      {assetsTable.isLoading ? (
+        <WalletAssetsTableSkeleton />
+      ) : (
+        <WalletAssetsTable
+          data={assetsTable.data}
+          showAll={showAll}
+          setShowAll={setShowAll}
+        />
+      )}
+      <Spacer axis="vertical" size={20} />
+    </>
+  )
+}

--- a/src/sections/wallet/assets/table/actions/WalletAssetsTableActions.tsx
+++ b/src/sections/wallet/assets/table/actions/WalletAssetsTableActions.tsx
@@ -9,23 +9,25 @@ import { ReactComponent as DollarIcon } from "assets/icons/DollarIcon.svg"
 import { ButtonTransparent } from "components/Button/Button"
 import { Dropdown } from "components/Dropdown/Dropdown"
 import { TableAction } from "components/Table/Table"
-import { useTranslation } from "react-i18next"
+import { Trans, useTranslation } from "react-i18next"
 import { theme } from "theme"
 import { isNotNil } from "utils/helpers"
+import { useSetAsFeePayment } from "api/payments"
 
 type Props = {
   toggleExpanded: () => void
   symbol: string
+  id: string
   onBuyClick: (() => void) | undefined
   onSellClick: (() => void) | undefined
   onTransferClick: () => void
-  onSetFeeAsPaymentClick: () => void
   couldBeSetAsPaymentFee: boolean
   isExpanded: boolean
 }
 
 export const WalletAssetsTableActions = (props: Props) => {
   const { t } = useTranslation()
+  const setFeeAsPayment = useSetAsFeePayment()
 
   const actionItems = [
     /*{
@@ -79,7 +81,44 @@ export const WalletAssetsTableActions = (props: Props) => {
           items={actionItems}
           onSelect={(item) => {
             if (item === "setAsFeePayment") {
-              props.onSetFeeAsPaymentClick()
+              setFeeAsPayment(props.id, {
+                onLoading: (
+                  <Trans
+                    t={t}
+                    i18nKey="wallet.assets.table.actions.payment.toast.onLoading"
+                    tOptions={{
+                      asset: props.symbol,
+                    }}
+                  >
+                    <span />
+                    <span className="highlight" />
+                  </Trans>
+                ),
+                onSuccess: (
+                  <Trans
+                    t={t}
+                    i18nKey="wallet.assets.table.actions.payment.toast.onSuccess"
+                    tOptions={{
+                      asset: props.symbol,
+                    }}
+                  >
+                    <span />
+                    <span className="highlight" />
+                  </Trans>
+                ),
+                onError: (
+                  <Trans
+                    t={t}
+                    i18nKey="wallet.assets.table.actions.payment.toast.onLoading"
+                    tOptions={{
+                      asset: props.symbol,
+                    }}
+                  >
+                    <span />
+                    <span className="highlight" />
+                  </Trans>
+                ),
+              })
             }
           }}
         >

--- a/src/utils/queryKeys.ts
+++ b/src/utils/queryKeys.ts
@@ -9,6 +9,11 @@ export const QUERY_KEY_PREFIX = "@block"
 
 export const QUERY_KEYS = {
   bestNumber: [QUERY_KEY_PREFIX, "bestNumber"],
+  assetsTable: (id: Maybe<AccountId32 | string>) => [
+    QUERY_KEY_PREFIX,
+    "assetsTable",
+    id?.toString(),
+  ],
   accountBalances: (id: Maybe<AccountId32 | string>) => [
     QUERY_KEY_PREFIX,
     "accountBalances",


### PR DESCRIPTION
Reworked Assets Table to reduce the number of the table re-rendering that was caused by calling multiple query hooks. I put all queries into one hook which should be triggered only once